### PR TITLE
Added "Using EJS with Webpack" in docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -535,6 +535,11 @@ fn(data, null, function(path, d){ // include callback
             <p><a href="https://github.com/mde/ejs/wiki/Using-EJS-with-Express">This GitHub Wiki page</a> explains various ways of passing EJS options to Express.</p>
           </div><!--//block-->
 
+          <div class="block">
+            <h3 class="sub-title text-center">Using EJS with Webpack</h3>
+            <p>The <a href="https://github.com/webdiscus/html-bundler-webpack-plugin">HTML bundler plugin for Webpack</a> compiles <a href="https://github.com/webdiscus/html-bundler-webpack-plugin#using-template-ejs">EJS templates</a> into static HTML files.</p>
+          </div><!--//block-->
+
         </div><!--//docs-inner-->
       </div><!--//container-->
     </section><!--//features-->


### PR DESCRIPTION
Hello @mde,

I'm the author of the [html-bundler-webpack-plugin](https://github.com/webdiscus/html-bundler-webpack-plugin).
This webpack plugin compile templates and [supports EJS](https://github.com/webdiscus/html-bundler-webpack-plugin#using-template-ejs) templating engine.

It would be useful for many developers to provide the link to the Webpack plugin in `docs`.
