### PR TITLE
Fix typo in EJS cache documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -489,7 +489,7 @@ import LRU from 'lru-cache';
 ejs.cache = LRU(100); // LRU cache with 100-item limit</code></pre>
 
 <p>If you want to clear the EJS cache, call <code>ejs.clearCache</code>. If you're using the
-LRU cache and need a different limit, simple reset `ejs.cache` to a new instance
+LRU cache and need a different limit, simply reset `ejs.cache` to a new instance
 of the LRU.</p>
           </div><!--//block-->
 


### PR DESCRIPTION
The word 'simply' is more appropriate here than 'simple'.